### PR TITLE
Adição API para criar tipoAlerta

### DIFF
--- a/src/controllers/TipoAlertaController.ts
+++ b/src/controllers/TipoAlertaController.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from 'express';
+import { criarTipoAlerta } from '../services/TipoAlertaServices';
+import { TipoAlerta } from '../entities/TipoAlerta';
+
+class TipoAlertaController {
+    async criarTipoAlerta(req: Request, res: Response): Promise<void> {
+        try {
+            const { Nome_Tipo_Alerta, Valor, Operador_Condicional, ID_Parametro } = req.body;
+
+            if (!Nome_Tipo_Alerta || !Valor || !Operador_Condicional || !ID_Parametro) {
+                res.status(400).json({ message: 'Todos os campos são obrigatórios' });
+                return;
+            }
+
+            const novoTipoAlerta: TipoAlerta = await criarTipoAlerta(Nome_Tipo_Alerta, Valor, Operador_Condicional, ID_Parametro);
+
+            res.status(201).json(novoTipoAlerta);
+        } catch (error) {
+            console.error('Erro ao criar tipo de alerta:', error);
+            res.status(500).json({ message: 'Erro ao criar tipo de alerta' });
+        }
+    }
+}
+
+export default new TipoAlertaController();

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,2 +1,3 @@
 export { default as UsuarioController } from "./UsuarioController"
 export { default as EstacaoController } from "./EstacaoController"
+export { default as TipoAlertaController } from "./TipoAlertaController"

--- a/src/routes/TipoAlertaRoutes.ts
+++ b/src/routes/TipoAlertaRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import { TipoAlertaController } from "../controllers";
+
+const routes = Router();
+
+routes.post("/criar", TipoAlertaController.criarTipoAlerta);
+
+export default routes;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -2,10 +2,12 @@ import { Router } from "express";
 
 import { default as UsuarioRoutes } from "./UsuarioRoutes";
 import { default as EstacaoRoutes } from "./EstacaoRoutes";
+import { default as TipoAlertaRoutes }from "./TipoAlertaRoutes";
 
 const router = Router();
 
 router.use("/usuario", UsuarioRoutes);
 router.use("/estacao", EstacaoRoutes);
+router.use("/tipoAlerta", TipoAlertaRoutes);
 
 export default router;

--- a/src/services/TipoAlertaServices.ts
+++ b/src/services/TipoAlertaServices.ts
@@ -1,0 +1,17 @@
+import { TipoAlerta } from "../entities/TipoAlerta";
+import SqlDataSource from "../data-source";
+import { Parametro } from "../entities/Parametro";
+
+async function criarTipoAlerta(nome: string, valor: number, operadorCondicional: string, parametro: Parametro): Promise<TipoAlerta> {
+    const tipoAlertaRepository = SqlDataSource.getRepository(TipoAlerta);
+
+    const novoTipoAlerta = new TipoAlerta();
+    novoTipoAlerta.Nome_Tipo_Alerta = nome;
+    novoTipoAlerta.Valor = valor;
+    novoTipoAlerta.Operador_Condicional = operadorCondicional;
+    novoTipoAlerta.parametro = parametro;
+
+    return await tipoAlertaRepository.save(novoTipoAlerta);
+}
+
+export { criarTipoAlerta };


### PR DESCRIPTION
Para testar tem que ter uma estação , um tipo de parâmetro e um parâmetro cadastrados no banco de dados
Rota: http://localhost:4000/tipoAlerta/criar

OBJETO:
{
  "Nome_Tipo_Alerta": "Alerta de Teste",
  "Valor": 10.5,
  "Operador_Condicional": ">",
  "ID_Parametro": 1
}


